### PR TITLE
Create a NGSI-LD broker loader that outputs the data directly in JSON-LD without any conversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,16 +62,6 @@ If you want to build the image locally from this repository, do the following:
 
 ---
 
-## Pull the Docker Image
-
-You can pull the image directly without building:
-
-```bash
-docker pull ghcr.io/your-org-or-username/sedimark-mage:latest
-```
-
----
-
 ## Run the Docker Container
 
 After building or pulling the image, you can run it:
@@ -88,6 +78,14 @@ docker run -itd --rm -p 6789:6789 -v ./default_repo:/home/src/default_repo sedim
 - `-p 6789:6789` – Exposes port `6789` so you can access Mage’s web interface at `http://localhost:6789`.
     
 - `-v ./default_repo:/home/src/default_repo` – Mounts your local directory (`./default_repo`) into the container’s filesystem at `/home/src/default_repo`. Any pipelines or configuration you create in that directory will be saved on your host machine.
+
+If NGSI-LD broker is needed, deploy the broker and place it in an external network, by default should be **sharde_network**, and run:
+
+```bash
+docker run -itd --rm -p 6789:6789 -v ./default_repo:/home/src/default_repo --network shared_network -e NGSI_LD_HOST=http://api-gateway:8080 -e sedimark-mage 
+```
+
+**api-gateway** is the name of the broker api as set in the docker compose of the broker and needs to be changed accordingly
 
 ### Access Mage
 

--- a/default_repo/custom_templates/blocks/jsonld_loader/jsonld_loader.py
+++ b/default_repo/custom_templates/blocks/jsonld_loader/jsonld_loader.py
@@ -9,8 +9,8 @@ if 'test' not in globals():
     from mage_ai.data_preparation.decorators import test
 
 
-def load_data(entity_id: str, start_time: str) -> Any:
-    context = os.getenv("NGSI_LD_LINK_CONTEXT", "")
+def load_temporal_data(entity_id: str, start_time: str) -> Any:
+    context = os.getenv("NGSI_LD_LINK_CONTEXT", "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld")
     host = os.getenv("NGSI_LD_HOST", "")
 
     if start_time == "":
@@ -36,6 +36,21 @@ def load_data(entity_id: str, start_time: str) -> Any:
     return response.json()
 
 
+def load_contextual_data(entity_id) -> Any:
+    context = os.getenv("NGSI_LD_LINK_CONTEXT", "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld")
+    host = os.getenv("NGSI_LD_HOST", "")
+
+    headers = {
+        "Link": f'<{context}>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+    }
+
+    url = f"{host}/ngsi-ld/v1/entities/{entity_id}"
+
+    response = requests.get(url, headers=headers)
+    response.raise_for_status()
+
+    return response.json()
+
 
 @data_loader
 def load_data(*args, **kwargs):
@@ -51,9 +66,10 @@ def load_data(*args, **kwargs):
     if entity_id == "":
         raise ValueError("entity_id must be provided")
 
-    data = load_data(entity_id, start_time)
+    temporal_data = load_temporal_data(entity_id, start_time)
+    contextual_data = load_contextual_data(entity_id)
 
-    return data
+    return temporal_data, contextual_data
 
 
 @test

--- a/default_repo/custom_templates/blocks/jsonld_loader/jsonld_loader.py
+++ b/default_repo/custom_templates/blocks/jsonld_loader/jsonld_loader.py
@@ -1,0 +1,64 @@
+import os
+import requests
+from typing import Any
+from datetime import datetime, timezone
+
+if 'data_loader' not in globals():
+    from mage_ai.data_preparation.decorators import data_loader
+if 'test' not in globals():
+    from mage_ai.data_preparation.decorators import test
+
+
+def load_data(entity_id: str, start_time: str) -> Any:
+    context = os.getenv("NGSI_LD_LINK_CONTEXT", "")
+    host = os.getenv("NGSI_LD_HOST", "")
+
+    if start_time == "":
+        start_time = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    end_time = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    headers = {
+        "Link": f'<{context}>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+    }
+
+    params = {
+        "timerel": "between",
+        "timeAt": start_time,
+        "endTimeAt": end_time
+    }
+
+    url = f"{host}/ngsi-ld/v1/temporal/entities/{entity_id}"
+
+    response = requests.get(url, params=params, headers=headers)
+    response.raise_for_status()
+
+    return response.json()
+
+
+
+@data_loader
+def load_data(*args, **kwargs):
+    """
+    Template code for loading data from any source.
+
+    Returns:
+        Anything (e.g. data frame, dictionary, array, int, str, etc.)
+    """
+    start_time = kwargs.get("date", "")
+    entity_id = kwargs.get("entity_id", "")
+
+    if entity_id == "":
+        raise ValueError("entity_id must be provided")
+
+    data = load_data(entity_id, start_time)
+
+    return data
+
+
+@test
+def test_output(output, *args) -> None:
+    """
+    Template code for testing the output of the block.
+    """
+    assert output is not None, 'The output is undefined'

--- a/default_repo/custom_templates/blocks/jsonld_loader/metadata.yaml
+++ b/default_repo/custom_templates/blocks/jsonld_loader/metadata.yaml
@@ -1,0 +1,14 @@
+block_type: data_loader
+color: null
+configuration:
+    entity_id: '{     "type": "drop_down",     "description": "This is the ID of the
+      entity that is stored in the NGSI-LD Broker",     "values": ["urn:ngsi-ld:WeatherInformation:Forecasted:Hourly:France:Les_Orres"]
+      }'
+    start_time: '{     "type": "date",     "description": "The date after which the
+      data from the broker will be loaded!",     "format": "%Y-%m-%dT%H:%M:%SZ" }'
+description: This block loads data from the local NGSI-LD broker directly in JSON-LD.
+language: python
+name: JSONLD_LOADER
+pipeline: {}
+tags: []
+user: {}

--- a/default_repo/custom_templates/blocks/jsonld_loader/metadata.yaml
+++ b/default_repo/custom_templates/blocks/jsonld_loader/metadata.yaml
@@ -1,11 +1,11 @@
 block_type: data_loader
 color: null
 configuration:
-    entity_id: '{     "type": "drop_down",     "description": "This is the ID of the
-      entity that is stored in the NGSI-LD Broker",     "values": ["urn:ngsi-ld:WeatherInformation:Forecasted:Hourly:France:Les_Orres"]
-      }'
-    start_time: '{     "type": "date",     "description": "The date after which the
-      data from the broker will be loaded!",     "format": "%Y-%m-%dT%H:%M:%SZ" }'
+  entity_id: '{     "type": "drop_down",     "description": "This is the ID of the
+    entity that is stored in the NGSI-LD Broker",     "values": ["urn:ngsi-ld:WeatherInformation:Forecasted:Hourly:France:Les_Orres"]
+    }'
+  start_time: '{     "type": "date",     "description": "The date after which the
+    data from the broker will be loaded!",     "format": "%Y-%m-%dT%H:%M:%SZ" }'
 description: This block loads data from the local NGSI-LD broker directly in JSON-LD.
 language: python
 name: JSONLD_LOADER


### PR DESCRIPTION
Create the JSONLD-LOADER template, which would sever as the default loader from NGSI-LD in case the formatter is used to format the data.